### PR TITLE
Add action.meta to reducer mapping and upgrade takeEvery, takeLatest usage for redux-saga >= 0.14 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 lib
+.idea

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react": "*",
     "react-redux": "*",
     "redux": "3.x",
-    "redux-saga": ">= 0.12",
+    "redux-saga": ">= 0.14",
     "reselect": "2.x"
   },
   "devDependencies": {

--- a/src/logic/reducer.js
+++ b/src/logic/reducer.js
@@ -19,7 +19,7 @@ let storageCache = {}
 export function createReducer (mapping, defaultValue) {
   return (state = defaultValue, action) => {
     if (mapping[action.type]) {
-      return mapping[action.type](state, action.payload)
+      return mapping[action.type](state, action.payload, action.meta)
     } else {
       return state
     }

--- a/src/saga/index.js
+++ b/src/saga/index.js
@@ -1,5 +1,4 @@
-import { takeEvery, takeLatest } from 'redux-saga'
-import { call, cancelled } from 'redux-saga/effects'
+import { call, cancelled, takeEvery, takeLatest } from 'redux-saga/effects'
 
 import { selectActionsFromLogic } from '../logic'
 


### PR DESCRIPTION
Some action creator libraries (redux-act, redux-form) use the action.meta dict to supply extra information with actions. This currently gets lost if you want to use one of these actions in a Logic instance. WIth this change the third argument to the reducer will be the action.meta dict.